### PR TITLE
Remove deprecated Eigen syntax for Eigen 3.4 compatibility

### DIFF
--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -84,7 +84,7 @@ void sort_indexes_bycol_Eigenmat(const refMatConst & v, matrixI & idx) { //check
   
   for(int n = 0; n < N;  n++) {
     // initialize original index locations
-    idx.col(n) = Eigen::VectorXi::LinSpaced(Eigen::Sequential,P,0,P-1); //fills with increasing values
+    idx.col(n) = Eigen::VectorXi::LinSpaced(P,0,P-1); //fills with increasing values
     
     // sort indexes based on comparing values in v
     std::sort(idx.col(n).data(), idx.col(n).data() + P,
@@ -106,7 +106,7 @@ void rel_sort_indexes_byrow_Eigenmat(const refMatConst & v, matrixI & idx) {
   
   for(int p = 0; p < P;  p++) {
     // initialize original index locations
-    idx.col(p) = Eigen::VectorXi::LinSpaced(Eigen::Sequential,N,0,N-1); //fills with increasing values
+    idx.col(p) = Eigen::VectorXi::LinSpaced(N,0,N-1); //fills with increasing values
     
     vector v_row = v.row(p); // get row of v
     
@@ -130,7 +130,7 @@ void sort_indexes_byrow_Eigenmat(const matrix & v, matrixI & idx) {
   
   for(int p = 0; p < P;  p++) {
     // initialize original index locations
-    idx.col(p) = Eigen::VectorXi::LinSpaced(Eigen::Sequential,N,0,N-1); //fills with increasing values
+    idx.col(p) = Eigen::VectorXi::LinSpaced(N,0,N-1); //fills with increasing values
     
     vector v_row = v.row(p); // get row of v
     
@@ -152,10 +152,10 @@ void sort_indexes_byrow_totalentry(const matrix & v, matrixI & idx) {
     idx.resize(P,N);
   }
   
-  // idx = Eigen::MatrixXi::LinSpaced(Eigen::Sequential,N*P,0,(N*P)-1);
+  // idx = Eigen::MatrixXi::LinSpaced(N*P,0,(N*P)-1);
   // Rcpp::Rcout << idx(P-1,0) << "\n";
   for(int p = 0; p < P;  p++) {
-    vectorI idx_row = vectorI::LinSpaced(Eigen::Sequential,N,0,N-1);
+    vectorI idx_row = vectorI::LinSpaced(N,0,N-1);
     vector v_row = v.row(p); // get row of v
     // sort indexes based on comparing values in v
     std::sort(idx_row.data(), idx_row.data() + N,
@@ -220,7 +220,7 @@ void rank_mat(const matrix & v, matrixI & rank) {
     vector v_row = v.row(p);
     
     // initialize original index locations
-    vectorI idx = Eigen::VectorXi::LinSpaced(Eigen::Sequential,N,0,N-1); //fills with increasing values
+    vectorI idx = Eigen::VectorXi::LinSpaced(N,0,N-1); //fills with increasing values
     
     // sort indexes based on comparing values in v
     std::sort(idx.data(), idx.data() + N,

--- a/src/trans_hilbert.cpp
+++ b/src/trans_hilbert.cpp
@@ -22,7 +22,7 @@ void trans_hilbert(const matrix & A, const matrix & B, int N, int M,
     // a_sort = true;
   }
   hilbert_sort_cgal_fun( B.data(), K, N, &idx_B[0] );
-  idx.col(1) = vectorI::LinSpaced(Eigen::Sequential,N,0,N-1);
+  idx.col(1) = vectorI::LinSpaced(N,0,N-1);
   for ( int n = 0; n < N; n++ ) {
     idx(idx_B[n],0) = idx_A[n];
   }

--- a/src/trans_rank.cpp
+++ b/src/trans_rank.cpp
@@ -26,7 +26,7 @@ void  trans_rank(const matrix & A, const matrix & B, int N, int M,
     // Rcpp::Rcout << "a sorted\n";
     std::iota (idx_A.begin(), idx_A.end(), 0);
   }
-  idx.col(1) = vectorI::LinSpaced(Eigen::Sequential,N,0,N-1);
+  idx.col(1) = vectorI::LinSpaced(N,0,N-1);
   for ( int n = 0; n < N; n++ ) {
     idx(idx_B[n],0) = idx_A[n];
     // Rcpp::Rcout << idx_A[n] << ", ";

--- a/src/trans_univariate.cpp
+++ b/src/trans_univariate.cpp
@@ -18,7 +18,7 @@ void  trans_univariate(const vector & A, const vector & B, int N, int M,
     sort_indexes(A, idx_A);
     // a_sort = true;
   }
-  idx.col(1) = vectorI::LinSpaced(Eigen::Sequential,N,0,N-1);
+  idx.col(1) = vectorI::LinSpaced(N,0,N-1);
   for ( int n = 0; n < N; n++ ) {
     // Rcpp::Rcout << idx_B[n] << ", " << idx_A[n] << "\n";
     idx(idx_B[n],0) = idx_A[n];

--- a/src/trans_univariate_approx_pwr.cpp
+++ b/src/trans_univariate_approx_pwr.cpp
@@ -14,14 +14,14 @@ void  trans_univariate_approx_pwr(const matrix & A, const matrix & B, int N, int
   matrixI idx_B(S,N);
   
   if (a_sort) { 
-    idx_A = vectorI::LinSpaced(Eigen::Sequential,N*S,0,(N*S)-1);
+    idx_A = vectorI::LinSpaced(N*S,0,(N*S)-1);
   } else {
     sort_indexes_byrow_totalentry(A, idx_A);
     a_sort = true;
   }
   sort_indexes_byrow_totalentry(B, idx_B);
   
-  idx.col(1) = vectorI::LinSpaced(Eigen::Sequential,N*S,0,(N*S)-1);
+  idx.col(1) = vectorI::LinSpaced(N*S,0,(N*S)-1);
   vecMapI idx_avec(idx_A.data(), idx_A.size());
   vecMapI idx_bvec(idx_B.data(), idx_B.size());
   for ( int i = 0; i < N*S; i ++ ) {


### PR DESCRIPTION
This PR updates your package's usage of `Vector::Linspaced(Eigen::Sequential, size, lower, upper)` to `Vector::Linspaced(size, lower, upper)`, as the former was simply an alias for the latter, and is marked as deprecated in Eigen 3.4. 

Without this change your package will give a `WARNING` under the next version of `RcppEigen`